### PR TITLE
フロント　ログイン・ログアウト・認証情報をヘッダーに載せる

### DIFF
--- a/frontend/tsuntsun/src/App.tsx
+++ b/frontend/tsuntsun/src/App.tsx
@@ -3,23 +3,27 @@ import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 import Main from "./pages/main";
 import Login from "./pages/login";
 import AfterLogin from "./pages/afterLogin";
+import { AuthProvider } from "./contexts/AuthContext";
+import PrivateRoute from "./component/Auth/PrivateRoute";
 
 function App() {
   return (
     <div className="App">
-      <Router>
-        <Switch>
-          <Route path="/login">
-            <Login />
-          </Route>
-          <Route path="/after-login">
-            <AfterLogin />
-          </Route>
-          <Route path="/">
-            <Main></Main>
-          </Route>
-        </Switch>
-      </Router>
+      <AuthProvider>
+        <Router>
+          <Switch>
+            <Route path="/login">
+              <Login />
+            </Route>
+            <Route path="/after-login">
+              <AfterLogin />
+            </Route>
+            <PrivateRoute path="/">
+              <Main></Main>
+            </PrivateRoute>
+          </Switch>
+        </Router>
+      </AuthProvider>
     </div>
   );
 }

--- a/frontend/tsuntsun/src/component/Auth/PrivateRoute.tsx
+++ b/frontend/tsuntsun/src/component/Auth/PrivateRoute.tsx
@@ -1,0 +1,25 @@
+import { Redirect, Route, RouteProps } from "react-router";
+import { useAuth } from "../../contexts/AuthContext";
+
+const PrivateRoute: React.FC<RouteProps> = ({ children, ...rest }) => {
+  const auth = useAuth();
+  return (
+    <Route
+      {...rest}
+      render={({ location }) =>
+        auth.isLoggedIn() ? (
+          children
+        ) : (
+          <Redirect
+            to={{
+              pathname: "/login",
+              state: { from: location },
+            }}
+          />
+        )
+      }
+    />
+  );
+};
+
+export default PrivateRoute;

--- a/frontend/tsuntsun/src/component/Auth/PrivateRoute.tsx
+++ b/frontend/tsuntsun/src/component/Auth/PrivateRoute.tsx
@@ -1,14 +1,21 @@
 import { Redirect, Route, RouteProps } from "react-router";
+import { useEffect } from "react";
 import { useAuth } from "../../contexts/AuthContext";
 
 const PrivateRoute: React.FC<RouteProps> = ({ children, ...rest }) => {
   const auth = useAuth();
-  console.log(auth.isLoggedIn());
+  let isLoggedIn: boolean;
+  useEffect(() => {
+    const f = async () => {
+      isLoggedIn = await auth.isLoggedIn();
+    };
+    f();
+  }, []);
   return (
     <Route
       {...rest}
       render={({ location }) =>
-        auth.isLoggedIn() ? (
+        isLoggedIn ? (
           children
         ) : (
           <Redirect

--- a/frontend/tsuntsun/src/component/Auth/PrivateRoute.tsx
+++ b/frontend/tsuntsun/src/component/Auth/PrivateRoute.tsx
@@ -5,27 +5,33 @@ import { useState } from "react";
 
 const PrivateRoute: React.FC<RouteProps> = ({ children, ...rest }) => {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [isLoaded, setIsLoaded] = useState(false);
   const auth = useAuth();
+
   useEffect(() => {
     const f = async () => {
       setIsLoggedIn(await auth.isLoggedIn());
-      console.log(await auth.isLoggedIn());
+      setIsLoaded(true);
+      console.log("await isLoggedIn", await auth.isLoggedIn());
     };
     f();
-  }, []);
+  }, [auth]);
+
   return (
     <Route
       {...rest}
       render={({ location }) =>
-        isLoggedIn ? (
+        isLoaded && isLoggedIn ? (
           children
-        ) : (
+        ) : isLoaded ? (
           <Redirect
             to={{
               pathname: "/login",
               state: { from: location },
             }}
           />
+        ) : (
+          <p>読み込み中</p>
         )
       }
     />

--- a/frontend/tsuntsun/src/component/Auth/PrivateRoute.tsx
+++ b/frontend/tsuntsun/src/component/Auth/PrivateRoute.tsx
@@ -3,6 +3,7 @@ import { useAuth } from "../../contexts/AuthContext";
 
 const PrivateRoute: React.FC<RouteProps> = ({ children, ...rest }) => {
   const auth = useAuth();
+  console.log(auth.isLoggedIn());
   return (
     <Route
       {...rest}

--- a/frontend/tsuntsun/src/component/Auth/PrivateRoute.tsx
+++ b/frontend/tsuntsun/src/component/Auth/PrivateRoute.tsx
@@ -9,7 +9,7 @@ const PrivateRoute: React.FC<RouteProps> = ({ children, ...rest }) => {
   useEffect(() => {
     const f = async () => {
       setIsLoggedIn(await auth.isLoggedIn());
-      console.log(isLoggedIn);
+      console.log(await auth.isLoggedIn());
     };
     f();
   }, []);

--- a/frontend/tsuntsun/src/component/Auth/PrivateRoute.tsx
+++ b/frontend/tsuntsun/src/component/Auth/PrivateRoute.tsx
@@ -1,13 +1,15 @@
 import { Redirect, Route, RouteProps } from "react-router";
 import { useEffect } from "react";
 import { useAuth } from "../../contexts/AuthContext";
+import { useState } from "react";
 
 const PrivateRoute: React.FC<RouteProps> = ({ children, ...rest }) => {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
   const auth = useAuth();
-  let isLoggedIn: boolean;
   useEffect(() => {
     const f = async () => {
-      isLoggedIn = await auth.isLoggedIn();
+      setIsLoggedIn(await auth.isLoggedIn());
+      console.log(isLoggedIn);
     };
     f();
   }, []);

--- a/frontend/tsuntsun/src/component/header.tsx
+++ b/frontend/tsuntsun/src/component/header.tsx
@@ -1,10 +1,15 @@
 import styled from "styled-components";
+import { useAuth } from "../contexts/AuthContext";
 
 const Header: React.FC<{
   name?: string;
 }> = ({ name }) => {
+  const auth = useAuth();
   const logout = () => {
-    window.location.href = "https://tsuntsun.herokuapp.com/login";
+    const logoutted = auth.logout();
+    if (logoutted) {
+      window.location.href = "https://tsuntsun.herokuapp.com/login";
+    }
     // axios
     //   .get("https://tsuntsun-api.herokuapp.com/api/line_logout")
     //   .then((res) => {

--- a/frontend/tsuntsun/src/component/header.tsx
+++ b/frontend/tsuntsun/src/component/header.tsx
@@ -7,7 +7,8 @@ const Header: React.FC<{
   const auth = useAuth();
   const logout = async () => {
     await auth.logout();
-    if (!auth.isLoggedIn()) {
+    const isLoggedIn = await auth.isLoggedIn();
+    if (!isLoggedIn) {
       window.location.href = "https://tsuntsun.herokuapp.com/login";
     }
   };

--- a/frontend/tsuntsun/src/component/header.tsx
+++ b/frontend/tsuntsun/src/component/header.tsx
@@ -6,19 +6,10 @@ const Header: React.FC<{
 }> = ({ name }) => {
   const auth = useAuth();
   const logout = async () => {
-    const logoutted = await auth.logout();
-    if (logoutted) {
+    await auth.logout();
+    if (!auth.isLoggedIn()) {
       window.location.href = "https://tsuntsun.herokuapp.com/login";
     }
-    // axios
-    //   .get("https://tsuntsun-api.herokuapp.com/api/line_logout")
-    //   .then((res) => {
-    //     console.log(res);
-    //     window.location.href = "https://tsuntsun.herokuapp.com/login";
-    //   })
-    //   .catch((res) => {
-    //     console.log(res);
-    //   });
   };
   return (
     <HeaderBase className="header">

--- a/frontend/tsuntsun/src/component/header.tsx
+++ b/frontend/tsuntsun/src/component/header.tsx
@@ -5,8 +5,8 @@ const Header: React.FC<{
   name?: string;
 }> = ({ name }) => {
   const auth = useAuth();
-  const logout = () => {
-    const logoutted = auth.logout();
+  const logout = async () => {
+    const logoutted = await auth.logout();
     if (logoutted) {
       window.location.href = "https://tsuntsun.herokuapp.com/login";
     }

--- a/frontend/tsuntsun/src/component/recommend.tsx
+++ b/frontend/tsuntsun/src/component/recommend.tsx
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
+import defaultAxios from "../utils/defaultAxios";
 import { TsumiObject } from "./tsumi";
 
 function Recommend() {
@@ -10,18 +11,12 @@ function Recommend() {
   const [site, setSite] = useState<TsumiObject>();
 
   useEffect(() => {
-    axios
-      .get("https://tsuntsun-api.herokuapp.com/api/users/1/tsundokus")
-      .then((res) => {
-        const recBook = res.data.find(
-          (t: TsumiObject) => t.category === "book"
-        );
-        setBook(recBook);
-        const recSite = res.data.find(
-          (t: TsumiObject) => t.category === "site"
-        );
-        setSite(recSite);
-      });
+    defaultAxios.get("/tsundokus").then((res) => {
+      const recBook = res.data.find((t: TsumiObject) => t.category === "book");
+      setBook(recBook);
+      const recSite = res.data.find((t: TsumiObject) => t.category === "site");
+      setSite(recSite);
+    });
   }, []);
   return (
     <RecommendBox className="recommend">

--- a/frontend/tsuntsun/src/component/resultArea.tsx
+++ b/frontend/tsuntsun/src/component/resultArea.tsx
@@ -4,7 +4,7 @@ import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
-import axios from "axios";
+import defaultAxios from "../utils/defaultAxios";
 import { TagObject, TsumiObject } from "./tsumi";
 
 function ResultArea() {
@@ -41,11 +41,9 @@ function ResultArea() {
   };
 
   useEffect(() => {
-    axios
-      .get("https://tsuntsun-api.herokuapp.com/api/users/1/tsundokus")
-      .then((res) => {
-        setTsumis(res.data);
-      });
+    defaultAxios.get("/tsundokus").then((res) => {
+      setTsumis(res.data);
+    });
   }, []);
 
   useEffect(() => {
@@ -73,17 +71,13 @@ function ResultArea() {
   const deleteFunc = (id: number) => {
     const willDelete = tsumis.find((t) => t.id === id);
     if (willDelete) {
-      axios
-        .delete(
-          `https://tsuntsun-api.herokuapp.com/api/users/1/tsundokus/${id}`
-        )
-        .then((res) => {
-          setDeleteTsumis((prev) => [...prev, willDelete]);
-          setTsumis((prev) => {
-            return prev.filter((t) => t.id !== id);
-          });
-          console.log(tsumis);
+      defaultAxios.delete(`/tsundokus/${id}`).then((res) => {
+        setDeleteTsumis((prev) => [...prev, willDelete]);
+        setTsumis((prev) => {
+          return prev.filter((t) => t.id !== id);
         });
+        console.log(tsumis);
+      });
     }
   };
 

--- a/frontend/tsuntsun/src/component/searchArea.tsx
+++ b/frontend/tsuntsun/src/component/searchArea.tsx
@@ -1,4 +1,4 @@
-import axios from "axios";
+import defaultAxios from "../utils/defaultAxios";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
 import { DarkButton } from "./button";
@@ -9,11 +9,9 @@ function SearchArea() {
   const [tags, setTags] = useState<TagObject[]>([]);
 
   useEffect(() => {
-    axios
-      .get("https://tsuntsun-api.herokuapp.com/api/users/1/tags")
-      .then((res) => {
-        setTags(res.data);
-      });
+    defaultAxios.get("/tags").then((res) => {
+      setTags(res.data);
+    });
   }, []);
   return (
     <Area className="search-area">

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -38,7 +38,10 @@ export const AuthProvider: React.FC = ({ children }) => {
           headers: { "Content-Type": "application/x-www-form-urlencoded" },
         }
       )
-      .then(() => (verifyed = true))
+      .then((res) => {
+        console.log(res);
+        verifyed = true;
+      })
       .catch((res) => {
         console.log(res);
       });

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -6,8 +6,8 @@ type auth = {
   idToken: () => string | null;
   accessToken: () => string | null;
   getloginHref: () => string;
-  getToken: (code: string, string: string) => boolean;
-  logout: () => boolean;
+  getToken: (code: string, string: string) => Promise<boolean>;
+  logout: () => Promise<boolean>;
 };
 
 const AuthContext = React.createContext<auth>({
@@ -15,8 +15,8 @@ const AuthContext = React.createContext<auth>({
   idToken: () => "",
   accessToken: () => "",
   getloginHref: () => "",
-  getToken: () => false,
-  logout: () => false,
+  getToken: async () => false,
+  logout: async () => false,
 });
 
 export const useAuth = () => {

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -16,6 +16,7 @@ export const AuthProvider: React.FC = ({ children }) => {
   const isLoggedIn = () => localStorage.getItem("isLoggedIn") === "true";
 
   const login = (code: string) => {
+    console.log("login");
     const data = {
       code: code,
       redirect_uri: "https://tsuntsun.herokuapp.com",
@@ -27,8 +28,9 @@ export const AuthProvider: React.FC = ({ children }) => {
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
       })
       .then((res) => {
-        console.log(res);
-      });
+        console.log("res", res);
+      })
+      .catch((res) => console.log("catchres", res));
     localStorage.setItem("isLoggedIn", "true");
     return;
   };

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -100,7 +100,7 @@ export const AuthProvider: React.FC = ({ children }) => {
             process.env.REACT_APP_CHANNEL_ID
           }&client_secret=${
             process.env.REACT_APP_CHANNEL_SECRET
-          }&accessToken=${accessToken()}`
+          }&access_token=${accessToken()}`
         )
         .catch((res) => {
           console.log(res);

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -37,7 +37,9 @@ export const AuthProvider: React.FC = ({ children }) => {
           headers: { "Content-Type": "application/x-www-form-urlencoded" },
         }
       )
-      .catch();
+      .catch((err) => {
+        return err.response;
+      });
     console.log(res.status, res.status === 200);
     return res.status === 200;
   };

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -28,20 +28,23 @@ export const AuthProvider: React.FC = ({ children }) => {
   const accessToken = () => localStorage.getItem("accessToken");
 
   const isLoggedIn = async () => {
-    const res = await axios
-      .get(
-        `https://api.line.me/oauth2/v2.1/verify?access_token=${
-          accessToken() ?? ""
-        }`,
-        {
-          headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        }
-      )
-      .catch((err) => {
-        return err.response;
-      });
-    console.log(res.status, res.status === 200);
-    return res.status === 200;
+    try {
+      const res = await axios
+        .get(
+          `https://api.line.me/oauth2/v2.1/verify?access_token=${
+            accessToken() ?? ""
+          }`,
+          {
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          }
+        )
+        .catch((err) => {
+          return err.response;
+        });
+      return res.status === 200;
+    } catch (error) {
+      return false;
+    }
   };
 
   const getloginHref = () => {

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -67,13 +67,14 @@ export const AuthProvider: React.FC = ({ children }) => {
         localStorage.setItem("accessToken", res.data.access_token);
         localStorage.setItem("idToken", res.data.id_token);
         localStorage.setItem("isLoggedIn", "true");
-        return true;
       })
       .catch((res) => {
         console.log("catch res", res);
-        return false;
+        localStorage.setItem("accessToken", "");
+        localStorage.setItem("idToken", "");
+        localStorage.setItem("isLoggedIn", "false");
       });
-    return false;
+    return isLoggedIn();
   };
 
   const logout = async (): Promise<boolean> => {

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -49,14 +49,13 @@ export const AuthProvider: React.FC = ({ children }) => {
     localStorage.setItem("nonce", "");
 
     // tokenの取得
-    const data = {
-      code: code,
-      redirect_uri: "https://tsuntsun.herokuapp.com/after-login",
-      client_id: process.env.REACT_APP_CHANNEL_ID,
-      client_secret: process.env.REACT_APP_CHANNEL_SECRET,
-    };
+    const params = new URLSearchParams();
+    params.append("code", code);
+    params.append("redirect_uri", "https://tsuntsun.herokuapp.com/after-login");
+    params.append("client_id", process.env.REACT_APP_CHANNEL_ID ?? "");
+    params.append("client_secret", process.env.REACT_APP_CHANNEL_SECRET ?? "");
     axios
-      .post("https://api.line.me/oauth2/v2.1/token", data, {
+      .post("https://api.line.me/oauth2/v2.1/token", params, {
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
       })
       .then((res) => {
@@ -66,7 +65,7 @@ export const AuthProvider: React.FC = ({ children }) => {
         localStorage.setItem("isLoggedIn", "true");
         return true;
       })
-      .catch((res) => console.log("catchres", res));
+      .catch((res) => console.log("catch res", res));
     return false;
   };
 

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -99,8 +99,17 @@ export const AuthProvider: React.FC = ({ children }) => {
         client_secret: process.env.REACT_APP_CHANNEL_SECRET,
         access_token: accessToken(),
       };
+      const params = new URLSearchParams();
+      params.append("client_id", process.env.REACT_APP_CHANNEL_ID ?? "");
+      params.append(
+        "client_secret",
+        process.env.REACT_APP_CHANNEL_SECRET ?? ""
+      );
+      params.append("access_token", accessToken() ?? "");
       await axios
-        .post("https://api.line.me/oauth2/v2.1/revoke", data)
+        .post("https://api.line.me/oauth2/v2.1/token", params, {
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        })
         .catch((res) => {
           console.log(res);
         })

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -50,6 +50,7 @@ export const AuthProvider: React.FC = ({ children }) => {
 
     // tokenの取得
     const params = new URLSearchParams();
+    params.append("grant_type", "authorization_code");
     params.append("code", code);
     params.append("redirect_uri", "https://tsuntsun.herokuapp.com/after-login");
     params.append("client_id", process.env.REACT_APP_CHANNEL_ID ?? "");

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -24,9 +24,9 @@ export const AuthProvider: React.FC = ({ children }) => {
     console.log("login");
     const state = Math.random().toString(32).substring(2);
     const nonce = Math.random().toString(32).substring(2);
-    const href = `https://access.line.me/oauth2/v2.1/authorize?response_type=code&client_id=${process.env.REACT_APP_CHANNEL_ID}&redirect_uri=https://tsuntsun.herokuapp.com&state=${state}&scope=profile%20openid&nonce=${nonce}&bot_prompt=aggressive`;
     localStorage.setItem("state", state);
     localStorage.setItem("nonce", nonce);
+    const href = `https://access.line.me/oauth2/v2.1/authorize?response_type=code&client_id=${process.env.REACT_APP_CHANNEL_ID}&redirect_uri=https://tsuntsun.herokuapp.com/afterLogin&state=${state}&scope=profile%20openid&nonce=${nonce}&bot_prompt=aggressive`;
     return href;
   };
 
@@ -39,7 +39,7 @@ export const AuthProvider: React.FC = ({ children }) => {
     console.log("login");
     const data = {
       code: code,
-      redirect_uri: "https://tsuntsun.herokuapp.com",
+      redirect_uri: "https://tsuntsun.herokuapp.com/afterLogin",
       client_id: process.env.REACT_APP_CHANNEL_ID,
       client_secret: process.env.REACT_APP_CHANNEL_SECRET,
     };

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -78,13 +78,12 @@ export const AuthProvider: React.FC = ({ children }) => {
   };
 
   const logout = async (): Promise<boolean> => {
-    const href = `https://api.line.me/oauth2/v2.1/revoke?client_id=${
-      process.env.REACT_APP_CHANNEL_ID
-    }&client_secret=${
-      process.env.REACT_APP_CHANNEL_SECRET
-    }&accessToken=${accessToken()}`;
+    const params = new URLSearchParams();
+    params.append("accessToken", accessToken() ?? "");
+    params.append("client_id", process.env.REACT_APP_CHANNEL_ID ?? "");
+    params.append("client_secret", process.env.REACT_APP_CHANNEL_SECRET ?? "");
     await axios
-      .post(href, {
+      .post("https://api.line.me/oauth2/v2.1/revoke", params, {
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
       })
       .then((res) => {

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -7,6 +7,7 @@ type auth = {
   accessToken: () => string | null;
   getloginHref: () => string;
   getToken: (code: string, string: string) => boolean;
+  logout: () => boolean;
 };
 
 const AuthContext = React.createContext<auth>({
@@ -15,6 +16,7 @@ const AuthContext = React.createContext<auth>({
   accessToken: () => "",
   getloginHref: () => "",
   getToken: () => false,
+  logout: () => false,
 });
 
 export const useAuth = () => {
@@ -70,12 +72,33 @@ export const AuthProvider: React.FC = ({ children }) => {
     return false;
   };
 
+  const logout = (): boolean => {
+    const href = `https://api.line.me/oauth2/v2.1/revoke?client_id=${
+      process.env.REACT_APP_CHANNEL_ID
+    }&client_secret=${
+      process.env.REACT_APP_CHANNEL_SECRET
+    }&accessToken=${accessToken()}`;
+    axios
+      .post(href, {
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      })
+      .then((res) => {
+        console.log(res);
+        localStorage.setItem("accessToken", "");
+        localStorage.setItem("idToken", "");
+        localStorage.setItem("isLoggedIn", "false");
+        return true;
+      });
+    return false;
+  };
+
   const value = {
     isLoggedIn,
     idToken,
     accessToken,
     getloginHref,
     getToken,
+    logout,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -36,7 +36,7 @@ export const AuthProvider: React.FC = ({ children }) => {
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
       }
     );
-    console.log(res.status);
+    console.log(res.status, res.status === 200);
     return res.status === 200;
   };
 

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -23,10 +23,10 @@ export const useAuth = () => {
   return useContext(AuthContext);
 };
 
-export const AuthProvider: React.FC = ({ children }) => {
-  const idToken = () => localStorage.getItem("idToken");
-  const accessToken = () => localStorage.getItem("accessToken");
+export const idToken = () => localStorage.getItem("idToken");
+export const accessToken = () => localStorage.getItem("accessToken");
 
+export const AuthProvider: React.FC = ({ children }) => {
   const isLoggedIn = async () => {
     try {
       const res = await axios
@@ -97,17 +97,25 @@ export const AuthProvider: React.FC = ({ children }) => {
     params.append("client_id", process.env.REACT_APP_CHANNEL_ID ?? "");
     params.append("client_secret", process.env.REACT_APP_CHANNEL_SECRET ?? "");
     params.append("accessToken", accessToken() ?? "");
-    await axios
-      .post("https://api.line.me/oauth2/v2.1/revoke", params, {
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      })
-      .catch((res) => {
-        console.log(res);
-      })
-      .finally(() => {
-        localStorage.setItem("accessToken", "");
-        localStorage.setItem("idToken", "");
-      });
+    try {
+      await axios
+        .post(
+          `https://api.line.me/oauth2/v2.1/revoke?client_id=${process.env.REACT_APP_CHANNEL_ID}&client_secret=${process.env.REACT_APP_CHANNEL_SECRET}&accessToken=${accessToken}`,
+          params,
+          {
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          }
+        )
+        .catch((res) => {
+          console.log(res);
+        })
+        .finally(() => {
+          localStorage.setItem("accessToken", "");
+          localStorage.setItem("idToken", "");
+        });
+    } catch (e) {
+      console.log(e);
+    }
   };
 
   const value = {

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -107,7 +107,7 @@ export const AuthProvider: React.FC = ({ children }) => {
       );
       params.append("access_token", accessToken() ?? "");
       await axios
-        .post("https://api.line.me/oauth2/v2.1/token", params, {
+        .post("https://api.line.me/oauth2/v2.1/revoke", params, {
           headers: { "Content-Type": "application/x-www-form-urlencoded" },
         })
         .catch((res) => {

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -93,18 +93,14 @@ export const AuthProvider: React.FC = ({ children }) => {
   };
 
   const logout = async (): Promise<void> => {
-    const params = new URLSearchParams();
-    params.append("client_id", process.env.REACT_APP_CHANNEL_ID ?? "");
-    params.append("client_secret", process.env.REACT_APP_CHANNEL_SECRET ?? "");
-    params.append("accessToken", accessToken() ?? "");
     try {
       await axios
         .post(
-          `https://api.line.me/oauth2/v2.1/revoke?client_id=${process.env.REACT_APP_CHANNEL_ID}&client_secret=${process.env.REACT_APP_CHANNEL_SECRET}&accessToken=${accessToken}`,
-          params,
-          {
-            headers: { "Content-Type": "application/x-www-form-urlencoded" },
-          }
+          `https://api.line.me/oauth2/v2.1/revoke?client_id=${
+            process.env.REACT_APP_CHANNEL_ID
+          }&client_secret=${
+            process.env.REACT_APP_CHANNEL_SECRET
+          }&accessToken=${accessToken()}`
         )
         .catch((res) => {
           console.log(res);

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -94,14 +94,13 @@ export const AuthProvider: React.FC = ({ children }) => {
 
   const logout = async (): Promise<void> => {
     try {
+      const data = {
+        client_id: process.env.REACT_APP_CHANNEL_ID,
+        client_secret: process.env.REACT_APP_CHANNEL_SECRET,
+        access_token: accessToken(),
+      };
       await axios
-        .post(
-          `https://api.line.me/oauth2/v2.1/revoke?client_id=${
-            process.env.REACT_APP_CHANNEL_ID
-          }&client_secret=${
-            process.env.REACT_APP_CHANNEL_SECRET
-          }&access_token=${accessToken()}`
-        )
+        .post("https://api.line.me/oauth2/v2.1/revoke", data)
         .catch((res) => {
           console.log(res);
         })

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -28,14 +28,16 @@ export const AuthProvider: React.FC = ({ children }) => {
   const accessToken = () => localStorage.getItem("accessToken");
 
   const isLoggedIn = async () => {
-    const res = await axios.get(
-      `https://api.line.me/oauth2/v2.1/verify?access_token=${
-        accessToken() ?? ""
-      }`,
-      {
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      }
-    );
+    const res = await axios
+      .get(
+        `https://api.line.me/oauth2/v2.1/verify?access_token=${
+          accessToken() ?? ""
+        }`,
+        {
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        }
+      )
+      .catch();
     console.log(res.status, res.status === 200);
     return res.status === 200;
   };

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -38,6 +38,8 @@ export const AuthProvider: React.FC = ({ children }) => {
   const getToken = (code: string, state: string): boolean => {
     // stateの確認
     const inputState = localStorage.getItem("state");
+    console.log("login", inputState, state, code, isLoggedIn());
+
     if (inputState !== state) {
       localStorage.setItem("isLoggedIn", "false");
       return false;
@@ -45,8 +47,6 @@ export const AuthProvider: React.FC = ({ children }) => {
     // stateなど一時保存したものの削除
     localStorage.setItem("state", "");
     localStorage.setItem("nonce", "");
-
-    console.log("login");
 
     // tokenの取得
     const data = {

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -62,6 +62,7 @@ export const AuthProvider: React.FC = ({ children }) => {
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
       })
       .then((res) => {
+        console.log("afterlogin", res);
         // tokenの保存
         localStorage.setItem("accessToken", res.data.access_token);
         localStorage.setItem("idToken", res.data.id_token);

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -38,7 +38,10 @@ export const AuthProvider: React.FC = ({ children }) => {
           headers: { "Content-Type": "application/x-www-form-urlencoded" },
         }
       )
-      .then(() => (verifyed = true));
+      .then(() => (verifyed = true))
+      .catch((res) => {
+        console.log(res);
+      });
 
     return verifyed;
   };

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -69,8 +69,10 @@ export const AuthProvider: React.FC = ({ children }) => {
         localStorage.setItem("isLoggedIn", "true");
         return true;
       })
-      .catch((res) => console.log("catch res", res));
-    return false;
+      .catch((res) => {
+        console.log("catch res", res);
+        return false;
+      });
   };
 
   const logout = (): boolean => {
@@ -89,8 +91,10 @@ export const AuthProvider: React.FC = ({ children }) => {
         localStorage.setItem("idToken", "");
         localStorage.setItem("isLoggedIn", "false");
         return true;
+      })
+      .catch(() => {
+        return false;
       });
-    return false;
   };
 
   const value = {

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -28,13 +28,16 @@ export const AuthProvider: React.FC = ({ children }) => {
   const accessToken = () => localStorage.getItem("accessToken");
 
   const isLoggedIn = async () => {
-    const params = new URLSearchParams();
-    params.append("accessToken", accessToken() ?? "");
     let verifyed = false;
     await axios
-      .post("https://api.line.me/oauth2/v2.1/verify", params, {
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      })
+      .get(
+        `https://api.line.me/oauth2/v2.1/verify?access_token=${
+          accessToken() ?? ""
+        }`,
+        {
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        }
+      )
       .then(() => (verifyed = true));
 
     return verifyed;
@@ -87,9 +90,9 @@ export const AuthProvider: React.FC = ({ children }) => {
 
   const logout = async (): Promise<void> => {
     const params = new URLSearchParams();
-    params.append("accessToken", accessToken() ?? "");
     params.append("client_id", process.env.REACT_APP_CHANNEL_ID ?? "");
     params.append("client_secret", process.env.REACT_APP_CHANNEL_SECRET ?? "");
+    params.append("accessToken", accessToken() ?? "");
     await axios
       .post("https://api.line.me/oauth2/v2.1/revoke", params, {
         headers: { "Content-Type": "application/x-www-form-urlencoded" },

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -1,0 +1,42 @@
+import axios from "axios";
+import React, { useContext } from "react";
+
+type auth = { isLoggedIn: () => boolean; login: (code: string) => void };
+
+const AuthContext = React.createContext<auth>({
+  isLoggedIn: () => false,
+  login: () => {},
+});
+
+export const useAuth = () => {
+  return useContext(AuthContext);
+};
+
+export const AuthProvider: React.FC = ({ children }) => {
+  const isLoggedIn = () => localStorage.getItem("isLoggedIn") === "true";
+
+  const login = (code: string) => {
+    const data = {
+      code: code,
+      redirect_uri: "https://tsuntsun.herokuapp.com",
+      client_id: process.env.REACT_APP_CHANNEL_ID,
+      client_secret: process.env.REACT_APP_CHANNEL_SECRET,
+    };
+    axios
+      .post("https://api.line.me/oauth2/v2.1/token", data, {
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      })
+      .then((res) => {
+        console.log(res);
+      });
+    localStorage.setItem("isLoggedIn", "true");
+    return;
+  };
+
+  const value = {
+    isLoggedIn,
+    login,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -37,7 +37,7 @@ export const AuthProvider: React.FC = ({ children }) => {
     return href;
   };
 
-  const getToken = (code: string, state: string): boolean => {
+  const getToken = async (code: string, state: string): Promise<boolean> => {
     // stateの確認
     const inputState = localStorage.getItem("state");
     console.log("login", inputState, state, code, isLoggedIn());
@@ -57,7 +57,7 @@ export const AuthProvider: React.FC = ({ children }) => {
     params.append("redirect_uri", "https://tsuntsun.herokuapp.com/after-login");
     params.append("client_id", process.env.REACT_APP_CHANNEL_ID ?? "");
     params.append("client_secret", process.env.REACT_APP_CHANNEL_SECRET ?? "");
-    axios
+    await axios
       .post("https://api.line.me/oauth2/v2.1/token", params, {
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
       })
@@ -73,15 +73,16 @@ export const AuthProvider: React.FC = ({ children }) => {
         console.log("catch res", res);
         return false;
       });
+    return false;
   };
 
-  const logout = (): boolean => {
+  const logout = async (): Promise<boolean> => {
     const href = `https://api.line.me/oauth2/v2.1/revoke?client_id=${
       process.env.REACT_APP_CHANNEL_ID
     }&client_secret=${
       process.env.REACT_APP_CHANNEL_SECRET
     }&accessToken=${accessToken()}`;
-    axios
+    await axios
       .post(href, {
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
       })
@@ -95,6 +96,7 @@ export const AuthProvider: React.FC = ({ children }) => {
       .catch(() => {
         return false;
       });
+    return false;
   };
 
   const value = {

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -28,25 +28,16 @@ export const AuthProvider: React.FC = ({ children }) => {
   const accessToken = () => localStorage.getItem("accessToken");
 
   const isLoggedIn = async () => {
-    let verifyed = false;
-    await axios
-      .get(
-        `https://api.line.me/oauth2/v2.1/verify?access_token=${
-          accessToken() ?? ""
-        }`,
-        {
-          headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        }
-      )
-      .then((res) => {
-        console.log(res);
-        verifyed = true;
-      })
-      .catch((res) => {
-        console.log(res);
-      });
+    const res = await axios.get(
+      `https://api.line.me/oauth2/v2.1/verify?access_token=${
+        accessToken() ?? ""
+      }`,
+      {
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      }
+    );
 
-    return verifyed;
+    return res.status === 200;
   };
 
   const getloginHref = () => {

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -7,7 +7,7 @@ type auth = {
   accessToken: () => string | null;
   getloginHref: () => string;
   getToken: (code: string, string: string) => Promise<boolean>;
-  logout: () => Promise<boolean>;
+  logout: () => Promise<void>;
 };
 
 const AuthContext = React.createContext<auth>({
@@ -16,7 +16,7 @@ const AuthContext = React.createContext<auth>({
   accessToken: () => "",
   getloginHref: () => "",
   getToken: async () => false,
-  logout: async () => false,
+  logout: async () => {},
 });
 
 export const useAuth = () => {
@@ -77,7 +77,7 @@ export const AuthProvider: React.FC = ({ children }) => {
     return isLoggedIn();
   };
 
-  const logout = async (): Promise<boolean> => {
+  const logout = async (): Promise<void> => {
     const params = new URLSearchParams();
     params.append("accessToken", accessToken() ?? "");
     params.append("client_id", process.env.REACT_APP_CHANNEL_ID ?? "");
@@ -88,15 +88,13 @@ export const AuthProvider: React.FC = ({ children }) => {
       })
       .then((res) => {
         console.log(res);
-        localStorage.setItem("accessToken", "");
-        localStorage.setItem("idToken", "");
-        localStorage.setItem("isLoggedIn", "false");
-        return true;
       })
-      .catch(() => {
-        return false;
+      .catch((res) => {
+        console.log(res);
       });
-    return false;
+    localStorage.setItem("accessToken", "");
+    localStorage.setItem("idToken", "");
+    localStorage.setItem("isLoggedIn", "false");
   };
 
   const value = {

--- a/frontend/tsuntsun/src/contexts/AuthContext.tsx
+++ b/frontend/tsuntsun/src/contexts/AuthContext.tsx
@@ -36,7 +36,7 @@ export const AuthProvider: React.FC = ({ children }) => {
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
       }
     );
-
+    console.log(res.status);
     return res.status === 200;
   };
 

--- a/frontend/tsuntsun/src/pages/afterLogin.tsx
+++ b/frontend/tsuntsun/src/pages/afterLogin.tsx
@@ -11,10 +11,13 @@ function AfterLogin() {
   const code = query.get("code") ?? "";
   const state = query.get("state") ?? "";
   useEffect(() => {
-    const result = auth.getToken(code, state);
-    setGotToken(result);
-    setFinishLoaging(true);
-    console.log(result, auth.isLoggedIn());
+    const f = async () => {
+      const result = await auth.getToken(code, state);
+      setGotToken(result);
+      setFinishLoaging(true);
+      console.log(result, auth.isLoggedIn());
+    };
+    f();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   return (

--- a/frontend/tsuntsun/src/pages/afterLogin.tsx
+++ b/frontend/tsuntsun/src/pages/afterLogin.tsx
@@ -1,18 +1,27 @@
-import { useEffect } from "react";
-import { useLocation } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { Redirect, useLocation } from "react-router-dom";
 import { useAuth } from "../contexts/AuthContext";
 
 function AfterLogin() {
+  const [finishLoaging, setFinishLoaging] = useState(false);
+  const [gotToken, setGotToken] = useState(false);
   const auth = useAuth();
   const search = useLocation().search;
   const query = new URLSearchParams(search);
   const code = query.get("code") ?? "";
   const state = query.get("state") ?? "";
   useEffect(() => {
-    auth.afterLogin(code, state);
+    const result = auth.getToken(code, state);
+    setGotToken(result);
+    setFinishLoaging(true);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-  return <body />;
+  return (
+    <>
+      {finishLoaging && gotToken && <Redirect to="/" />}
+      {finishLoaging && !gotToken && <Redirect to="/login" />}
+    </>
+  );
 }
 
 export default AfterLogin;

--- a/frontend/tsuntsun/src/pages/afterLogin.tsx
+++ b/frontend/tsuntsun/src/pages/afterLogin.tsx
@@ -15,7 +15,6 @@ function AfterLogin() {
       const result = await auth.getToken(code, state);
       setGotToken(result);
       setFinishLoaging(true);
-      console.log(result, auth.isLoggedIn());
     };
     f();
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/tsuntsun/src/pages/afterLogin.tsx
+++ b/frontend/tsuntsun/src/pages/afterLogin.tsx
@@ -14,7 +14,7 @@ function AfterLogin() {
     const result = auth.getToken(code, state);
     setGotToken(result);
     setFinishLoaging(true);
-    console.log(result, auth.isLoggedIn);
+    console.log(result, auth.isLoggedIn());
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   return (

--- a/frontend/tsuntsun/src/pages/afterLogin.tsx
+++ b/frontend/tsuntsun/src/pages/afterLogin.tsx
@@ -14,6 +14,7 @@ function AfterLogin() {
     const result = auth.getToken(code, state);
     setGotToken(result);
     setFinishLoaging(true);
+    console.log(result, auth.isLoggedIn);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   return (

--- a/frontend/tsuntsun/src/pages/afterLogin.tsx
+++ b/frontend/tsuntsun/src/pages/afterLogin.tsx
@@ -1,25 +1,14 @@
-import axios from "axios";
 import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
+import { useAuth } from "../contexts/AuthContext";
 
 function AfterLogin() {
-  const location = useLocation();
-  const search = location.search;
+  const auth = useAuth();
+  const search = useLocation().search;
   const query = new URLSearchParams(search);
+  const code = query.get("code") ?? "";
   useEffect(() => {
-    const data = {
-      code: query.get("code") ? query.get("code") : "",
-      redirect_uri: "https://tsuntsun.herokuapp.com",
-      client_id: process.env.REACT_APP_CHANNEL_ID,
-      client_secret: process.env.REACT_APP_CHANNEL_SECRET,
-    };
-    axios
-      .post("https://api.line.me/oauth2/v2.1/token", data, {
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      })
-      .then((res) => {
-        console.log(res);
-      });
+    auth.login(code);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   return <body></body>;

--- a/frontend/tsuntsun/src/pages/afterLogin.tsx
+++ b/frontend/tsuntsun/src/pages/afterLogin.tsx
@@ -7,11 +7,12 @@ function AfterLogin() {
   const search = useLocation().search;
   const query = new URLSearchParams(search);
   const code = query.get("code") ?? "";
+  const state = query.get("state") ?? "";
   useEffect(() => {
-    auth.login(code);
+    auth.afterLogin(code, state);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-  return <body></body>;
+  return <body />;
 }
 
 export default AfterLogin;

--- a/frontend/tsuntsun/src/pages/login.tsx
+++ b/frontend/tsuntsun/src/pages/login.tsx
@@ -13,7 +13,7 @@ function Login() {
         <img
           src={`${process.env.PUBLIC_URL}/LineLoginButtonImage/images/DeskTop/2x/44dp/btn_login_base.png`}
           alt="lINEでログイン"
-          onClick={() => (window.location.href = auth.login())}
+          onClick={() => (window.location.href = auth.getloginHref())}
         ></img>
       </div>
     </body>

--- a/frontend/tsuntsun/src/pages/login.tsx
+++ b/frontend/tsuntsun/src/pages/login.tsx
@@ -1,4 +1,7 @@
+import { useAuth } from "../contexts/AuthContext";
+
 function Login() {
+  const auth = useAuth();
   return (
     <body>
       <div className="login">
@@ -10,15 +13,7 @@ function Login() {
         <img
           src={`${process.env.PUBLIC_URL}/LineLoginButtonImage/images/DeskTop/2x/44dp/btn_login_base.png`}
           alt="lINEでログイン"
-          onClick={(e) =>
-            (window.location.href = `https://access.line.me/oauth2/v2.1/authorize?response_type=code&client_id=${
-              process.env.REACT_APP_CHANNEL_ID
-            }&redirect_uri=https://tsuntsun.herokuapp.com&state=${Math.random()
-              .toString(32)
-              .substring(2)}&scope=profile%20openid&nonce=${Math.random()
-              .toString(32)
-              .substring(2)}&bot_prompt=aggressive`)
-          }
+          onClick={() => (window.location.href = auth.login())}
         ></img>
       </div>
     </body>

--- a/frontend/tsuntsun/src/pages/main.tsx
+++ b/frontend/tsuntsun/src/pages/main.tsx
@@ -7,50 +7,33 @@ import Header from "../component/header";
 import Recommend from "../component/recommend";
 import ResultArea from "../component/resultArea";
 import SearchArea from "../component/searchArea";
+import { useAuth } from "../contexts/AuthContext";
 
 function Main() {
-  const location = useLocation();
-  const search = location.search;
+  const auth = useAuth();
+  const search = useLocation().search;
   const query = new URLSearchParams(search);
+  const code = query.get("code") ?? "";
+  const state = query.get("state") ?? "";
+
   const [name, setName] = useState();
 
   useEffect(() => {
-    const code = query.get("code");
-    const params = new URLSearchParams();
-    params.append("grant_type", "authorization_code");
-    params.append("code", code ? code : "");
-    params.append("redirect_uri", "https://tsuntsun.herokuapp.com");
-    params.append("client_id", process.env.REACT_APP_CHANNEL_ID!);
-    params.append("client_secret", process.env.REACT_APP_CHANNEL_SECRET!);
-    const data = {
-      grant_type: "authorization_code",
-      code: query.get("code") ? query.get("code") : "",
-      redirect_uri: "https://tsuntsun.herokuapp.com",
-      client_id: process.env.REACT_APP_CHANNEL_ID,
-      client_secret: process.env.REACT_APP_CHANNEL_SECRET,
-    };
-    console.log(data);
+    auth.afterLogin(code, state);
+    const bodyFormData = new FormData();
+    const idToken = auth.idToken();
+    const accessToken = auth.accessToken();
+
+    if (idToken === null || accessToken === null) {
+      return;
+    }
+
+    bodyFormData.append("id_token", idToken);
+    bodyFormData.append("access_token", accessToken);
     axios
-      .post("https://api.line.me/oauth2/v2.1/token", params, {
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      })
+      .post("https://tsuntsun-api.herokuapp.com/api/line_login", bodyFormData)
       .then((res) => {
-        console.log(res);
-        const bodyFormData = new FormData();
-        bodyFormData.append("id_token", res.data.id_token);
-        bodyFormData.append("access_token", res.data.access_token);
-        axios
-          .post(
-            "https://tsuntsun-api.herokuapp.com/api/line_login",
-            bodyFormData
-          )
-          .then((res) => {
-            setName(res.data.name);
-            console.log(res);
-          });
-      })
-      .catch((error) => {
-        console.log(error);
+        setName(res.data.name);
       });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -59,10 +42,10 @@ function Main() {
       <Header name={name}></Header>
       <Body>
         <div className="main">
-          <Recommend></Recommend>
-          <AddButton></AddButton>
-          <SearchArea></SearchArea>
-          <ResultArea></ResultArea>
+          <Recommend />
+          <AddButton />
+          <SearchArea />
+          <ResultArea />
         </div>
       </Body>
     </>

--- a/frontend/tsuntsun/src/pages/main.tsx
+++ b/frontend/tsuntsun/src/pages/main.tsx
@@ -11,10 +11,6 @@ import { useAuth } from "../contexts/AuthContext";
 
 function Main() {
   const auth = useAuth();
-  const search = useLocation().search;
-  const query = new URLSearchParams(search);
-  const code = query.get("code") ?? "";
-  const state = query.get("state") ?? "";
 
   const [name, setName] = useState();
 

--- a/frontend/tsuntsun/src/pages/main.tsx
+++ b/frontend/tsuntsun/src/pages/main.tsx
@@ -8,6 +8,7 @@ import Recommend from "../component/recommend";
 import ResultArea from "../component/resultArea";
 import SearchArea from "../component/searchArea";
 import { useAuth } from "../contexts/AuthContext";
+import defaultAxios from "../utils/defaultAxios";
 
 function Main() {
   const auth = useAuth();
@@ -25,11 +26,9 @@ function Main() {
 
     bodyFormData.append("id_token", idToken);
     bodyFormData.append("access_token", accessToken);
-    axios
-      .post("https://tsuntsun-api.herokuapp.com/api/line_login", bodyFormData)
-      .then((res) => {
-        setName(res.data.name);
-      });
+    defaultAxios.post("/line_login", bodyFormData).then((res) => {
+      setName(res.data.name);
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   return (

--- a/frontend/tsuntsun/src/pages/main.tsx
+++ b/frontend/tsuntsun/src/pages/main.tsx
@@ -19,7 +19,6 @@ function Main() {
   const [name, setName] = useState();
 
   useEffect(() => {
-    auth.afterLogin(code, state);
     const bodyFormData = new FormData();
     const idToken = auth.idToken();
     const accessToken = auth.accessToken();

--- a/frontend/tsuntsun/src/utils/defaultAxios.tsx
+++ b/frontend/tsuntsun/src/utils/defaultAxios.tsx
@@ -8,17 +8,20 @@ const createAxiosInstance = () => {
 
   axiosInstance.interceptors.request.use((request) => {
     request.headers["Authorization"] = accessToken();
-    console.dir("request", request);
+    console.log("request");
+    console.dir(request);
     return request;
   });
 
   axiosInstance.interceptors.response.use(
     (response) => {
-      console.dir("response", response);
+      console.log("response");
+      console.dir(response);
       return response;
     },
     (error) => {
-      console.log("error", error);
+      console.log("error");
+      console.log(error);
     }
   );
   return axiosInstance;

--- a/frontend/tsuntsun/src/utils/defaultAxios.tsx
+++ b/frontend/tsuntsun/src/utils/defaultAxios.tsx
@@ -1,0 +1,26 @@
+import axios from "axios";
+import { accessToken } from "../contexts/AuthContext";
+
+const createAxiosInstance = () => {
+  const axiosInstance = axios.create({
+    baseURL: "https://tsuntsun-api.herokuapp.com/api/",
+  });
+
+  axiosInstance.interceptors.request.use((request) => {
+    request.headers["Authorization"] = accessToken();
+    console.dir(request);
+    return request;
+  });
+
+  axiosInstance.interceptors.response.use(
+    (response) => response,
+    (error) => {
+      console.log(error);
+    }
+  );
+  return axiosInstance;
+};
+
+const defaultAxios = createAxiosInstance();
+
+export default defaultAxios;

--- a/frontend/tsuntsun/src/utils/defaultAxios.tsx
+++ b/frontend/tsuntsun/src/utils/defaultAxios.tsx
@@ -8,14 +8,17 @@ const createAxiosInstance = () => {
 
   axiosInstance.interceptors.request.use((request) => {
     request.headers["Authorization"] = accessToken();
-    console.dir(request);
+    console.dir("request", request);
     return request;
   });
 
   axiosInstance.interceptors.response.use(
-    (response) => response,
+    (response) => {
+      console.dir("response", response);
+      return response;
+    },
     (error) => {
-      console.log(error);
+      console.log("error", error);
     }
   );
   return axiosInstance;


### PR DESCRIPTION
一生修正のコミットしてた。

フロントはherokuにデプロイしてるので、ログインログアウトはそこで試せると思います。

認証情報の方は、コンソールに書き出されてるオブジェクト見たら載ってるのわかると思う。

~~API叩けてないのは別PRで修正します~~
治せたので一緒に入れた